### PR TITLE
Fix build failure on Windows

### DIFF
--- a/src/FOLD.cpp
+++ b/src/FOLD.cpp
@@ -1,6 +1,7 @@
 #include "oversample.hpp"
 #include "plugin.hpp"
 #include "widgets.hpp"
+#include <math.h>
 
 // define FOLD_DEBUG
 
@@ -77,7 +78,7 @@ struct FOLD : Module {
         float amp = in * ampOffset;
 
         // TODO should we use a fast approximation for cosf()?
-        return std::cosf(kTwoPi * (amp + phaseOffset));
+        return cosf(kTwoPi * (amp + phaseOffset));
     }
 
     float oversampleFold(float in, float timbre) {


### PR DESCRIPTION
```
src/FOLD.cpp: In member function 'float FOLD::fold(float, float)':
src/FOLD.cpp:80:21: error: 'cosf' is not a member of 'std'; did you mean 'cosh'?
   80 |         return std::cosf(kTwoPi * (amp + phaseOffset));
      |                     ^~~~
      |                     cosh
make: *** [../../compile.mk:72: build/src/FOLD.cpp.o] Error 1
make: *** Waiting for unfinished jobs....
```